### PR TITLE
update the store and drift pod more carefully in case of swarm bug

### DIFF
--- a/engine/notify.go
+++ b/engine/notify.go
@@ -19,6 +19,7 @@ var (
 	NotifyPodMissing = "LAIN found pod missing, ready to redeployd it"
 	NotifyPodDown    = "LAIN found pod down, ready to restart it"
 	NotifyLetPodGo   = "LAIN found pod restart too many times in a short period, will let it go"
+	NotifyPodIPLost  = "LAIN found pod lost IP, please inform the SA team"
 )
 
 type notifyController struct {

--- a/engine/podgroup.go
+++ b/engine/podgroup.go
@@ -43,6 +43,19 @@ func (pgCtrl *podGroupController) Inspect() PodGroupWithSpec {
 	return PodGroupWithSpec{pgCtrl.spec, pgCtrl.prevState, pgCtrl.group}
 }
 
+func (pgCtrl *podGroupController) IsHealthy() bool {
+	pgCtrl.RLock()
+	defer pgCtrl.RUnlock()
+	for i := 0; i < pgCtrl.spec.NumInstances; i += 1 {
+		pc := pgCtrl.podCtrls[i]
+		if pc.pod.PodIp() == "" {
+			ntfController.Send(NewNotifySpec(pc.spec.Namespace, pc.spec.Name, i, NotifyPodIPLost))
+			return false
+		}
+	}
+	return true
+}
+
 func (pgCtrl *podGroupController) IsRemoved() bool {
 	pgCtrl.RLock()
 	defer pgCtrl.RUnlock()

--- a/engine/podgroup_ops.go
+++ b/engine/podgroup_ops.go
@@ -28,10 +28,15 @@ func (op pgOperSaveStore) Do(pgCtrl *podGroupController, c cluster.Cluster, stor
 		pgCtrl.RUnlock()
 	}()
 	pg := pgCtrl.Inspect()
-	if err := store.Set(pgCtrl.storedKey, pg, op.force); err != nil {
-		log.Warnf("[Store] Failed to save pod group %s, %s", pgCtrl.storedKey, err)
-		_err = err
+	if pgCtrl.IsHealthy() {
+		if err := store.Set(pgCtrl.storedKey, pg, op.force); err != nil {
+			log.Warnf("[Store] Failed to save pod group %s, %s", pgCtrl.storedKey, err)
+			_err = err
+		}
+	} else {
+		log.Warnf("Some pods lost IP, will not save pod group %s", pgCtrl.storedKey)
 	}
+
 	return false
 }
 

--- a/engine/runtimes.go
+++ b/engine/runtimes.go
@@ -152,6 +152,13 @@ func (pod Pod) NodeIp() string {
 	return ""
 }
 
+func (pod Pod) PodIp() string {
+	if len(pod.Containers) > 0 {
+		return pod.Containers[0].NodeIp
+	}
+	return ""
+}
+
 type PodGroup struct {
 	Pods []Pod
 	BaseRuntime


### PR DESCRIPTION
- stop the engine when too many nodes lost in a short period
- notify the callback if any pod lost IP when deploying, also will not store it