### PR TITLE
make cloud_volume_root and volume_root configable

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -761,6 +761,7 @@ func New(cluster cluster.Cluster, store storage.Store) (*OrcEngine, error) {
 		stop:         nil,
 		clstrFailCnt: 0,
 	}
+	configSpecsVars(store)
 	watchResource(store)
 	WatchEngineConfig(engine)
 

--- a/engine/specs.go
+++ b/engine/specs.go
@@ -5,8 +5,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/laincloud/deployd/storage"
 	"github.com/mijia/adoc"
 	"github.com/mijia/go-generics"
+	"github.com/mijia/sweb/log"
 )
 
 const (
@@ -21,16 +23,22 @@ const (
 	kLainLastPodSpecKey = "last_spec"
 	kLainPgOpingKey     = "operating"
 
-	kLainVolumeRoot      = "/data/lain/volumes"
-	kLainCloudVolumeRoot = "/data/lain/cloud-volumes"
-	kLainLabelPrefix     = "cc.bdp.lain.deployd"
-	kLainLogVolumePath   = "/lain/logs"
+	kLainLabelPrefix   = "cc.bdp.lain.deployd"
+	kLainLogVolumePath = "/lain/logs"
 
 	MinPodSetupTime = 0
 	MaxPodSetupTime = 300
 
 	MinPodKillTimeout = 10
 	MaxPodKillTimeout = 120
+
+	etcdCloudVolumeRootKey = "/lain/config/cloud_volumes_root"
+	etcdVolumeRootKey      = "/lain/config/volumes_root"
+)
+
+var (
+	kLainVolumeRoot      = "/data/lain/volumes"
+	kLainCloudVolumeRoot = "/data/lain/cloud-volumes"
 )
 
 type ImSpec struct {
@@ -49,6 +57,18 @@ type ContainerLabel struct {
 	DriftCount     int
 	ContainerIndex int
 	Annotation     string
+}
+
+func configSpecsVars(store storage.Store) error {
+	if v, err := store.GetRaw(etcdCloudVolumeRootKey); err == nil {
+		kLainCloudVolumeRoot = v
+	}
+
+	if v, err := store.GetRaw(etcdVolumeRootKey); err == nil {
+		kLainVolumeRoot = v
+	}
+	log.Debugf("cloud_volume_root: %s, volumes_root: %s", kLainCloudVolumeRoot, kLainVolumeRoot)
+	return nil
 }
 
 func (label ContainerLabel) NameAffinity() string {

--- a/storage/store.go
+++ b/storage/store.go
@@ -13,6 +13,7 @@ var (
 
 type Store interface {
 	Get(key string, v interface{}) error
+	GetRaw(key string) (string, error)
 	Set(key string, v interface{}, force ...bool) error
 	SetWithTTL(key string, v interface{}, ttlSec int, force ...bool) error
 	Watch(key string) chan string


### PR DESCRIPTION
commit1: 通过etcd,配置cloud_volume_root， 可以很方便的将目录指向moosefs和ceph的挂载点
commit2: 通过swarm的event来减小deployd感知容器状态的延迟，我的测试基本可以2s内拉起容器

@bibaijin @supermeng review一下